### PR TITLE
Improve cross reference resolution

### DIFF
--- a/example/conf.py
+++ b/example/conf.py
@@ -81,7 +81,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/example/conf.py
+++ b/example/conf.py
@@ -81,7 +81,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/example/index.rst
+++ b/example/index.rst
@@ -12,6 +12,7 @@ Welcome to Thrift Example's documentation!
 
    usage
    reference
+   xreftest
 
 
 Indices and tables

--- a/example/xreftest.rst
+++ b/example/xreftest.rst
@@ -4,22 +4,22 @@ Cross References test page
 
 :thrift:module:`Example`
 
-:thrift:namespace:`tutorial`
+:thrift:namespace:`Example.tutorial`
 
-:thrift:constant:`MAPCONSTANT`
+:thrift:constant:`Example.MAPCONSTANT`
 
-:thrift:typedef:`MyInteger`
+:thrift:typedef:`Example.MyInteger`
 
-:thrift:enum:`Operation`
+:thrift:enum:`Example.Operation`
 
-:thrift:enum_field:`Operation.ADD`
+:thrift:enum_field:`Example.Operation.ADD`
 
-:thrift:struct:`Work`
+:thrift:struct:`Example.Work`
 
-:thrift:struct_field:`Work.comment`
+:thrift:struct_field:`Example.Work.comment`
 
-:thrift:exception:`InvalidOperation`
+:thrift:exception:`Example.InvalidOperation`
 
-:thrift:service:`Calculator`
+:thrift:service:`Example.Calculator`
 
-:thrift:service_method:`Calculator.ping`
+:thrift:service_method:`Example.Calculator.ping`

--- a/example/xreftest.rst
+++ b/example/xreftest.rst
@@ -4,7 +4,7 @@ Cross References test page
 
 :thrift:module:`Example`
 
-:thrift:namespace:`Example.tutorial`
+.. :thrift:namespace:`Example.tutorial`
 
 :thrift:constant:`Example.MAPCONSTANT`
 
@@ -23,3 +23,53 @@ Cross References test page
 :thrift:service:`Example.Calculator`
 
 :thrift:service_method:`Example.Calculator.ping`
+
+Titled crossrefs
+----------------
+
+:thrift:module:`Titled module ref <Example>`
+
+.. :thrift:namespace:`Titled namespace ref <Example.tutorial>`
+
+:thrift:constant:`Titled constant ref <Example.MAPCONSTANT>`
+
+:thrift:typedef:`Titled typedef ref <Example.MyInteger>`
+
+:thrift:enum:`Titled enum ref <Example.Operation>`
+
+:thrift:enum_field:`Titled enum_field ref <Example.Operation.ADD>`
+
+:thrift:struct:`Titled struct ref <Example.Work>`
+
+:thrift:struct_field:`Titled struct_field ref <Example.Work.comment>`
+
+:thrift:exception:`Titled exception ref <Example.InvalidOperation>`
+
+:thrift:service:`Titled service ref <Example.Calculator>`
+
+:thrift:service_method:`Titled service_method ref <Example.Calculator.ping>`
+
+Crossrefs without explicit module
+---------------------------------
+
+:thrift:module:`Example`
+
+.. :thrift:namespace:`tutorial`
+
+:thrift:constant:`MAPCONSTANT`
+
+:thrift:typedef:`MyInteger`
+
+:thrift:enum:`Operation`
+
+:thrift:enum_field:`Operation.ADD`
+
+:thrift:struct:`Work`
+
+:thrift:struct_field:`Work.comment`
+
+:thrift:exception:`InvalidOperation`
+
+:thrift:service:`Calculator`
+
+:thrift:service_method:`Calculator.ping`

--- a/example/xreftest.rst
+++ b/example/xreftest.rst
@@ -20,6 +20,8 @@ Cross References test page
 
 :thrift:exception:`Example.InvalidOperation`
 
+:thrift:exception_field:`Example.InvalidOperation.why`
+
 :thrift:service:`Example.Calculator`
 
 :thrift:service_method:`Example.Calculator.ping`
@@ -45,6 +47,8 @@ Titled crossrefs
 
 :thrift:exception:`Titled exception ref <Example.InvalidOperation>`
 
+:thrift:exception_field:`Titled exception_field ref <Example.InvalidOperation.why>`
+
 :thrift:service:`Titled service ref <Example.Calculator>`
 
 :thrift:service_method:`Titled service_method ref <Example.Calculator.ping>`
@@ -69,6 +73,8 @@ Crossrefs without explicit module
 :thrift:struct_field:`Work.comment`
 
 :thrift:exception:`InvalidOperation`
+
+:thrift:exception_field:`InvalidOperation.why`
 
 :thrift:service:`Calculator`
 

--- a/example/xreftest.rst
+++ b/example/xreftest.rst
@@ -1,0 +1,25 @@
+
+Cross References test page
+==========================
+
+:thrift:module:`Example`
+
+:thrift:namespace:`tutorial`
+
+:thrift:constant:`MAPCONSTANT`
+
+:thrift:typedef:`MyInteger`
+
+:thrift:enum:`Operation`
+
+:thrift:enum_field:`Operation.ADD`
+
+:thrift:struct:`Work`
+
+:thrift:struct_field:`Work.comment`
+
+:thrift:exception:`InvalidOperation`
+
+:thrift:service:`Calculator`
+
+:thrift:service_method:`Calculator.ping`

--- a/sphinx_thrift/domain.py
+++ b/sphinx_thrift/domain.py
@@ -247,15 +247,16 @@ class ThriftServiceMethod(ThriftObject):
 
 class ThriftXRefRole(XRefRole):
     @staticmethod
-    def find_target(env, typ: str, target: str) -> Optional[Tuple[str,str]]:
+    def find_target(env, typ: str, target: str) -> Optional[Tuple[str, str]]:
         if typ == 'module':
             target = f'None.{target}'
         moduleless_results = []
         for sig, obj in env.domaindata['thrift']['objects'].items():
             if str(sig.module) + '.' + sig.name == target:
-                return (obj[0],f'{sig.module}.{sig.name}:{sig.kind}')
+                return (obj[0], f'{sig.module}.{sig.name}:{sig.kind}')
             if sig.name == target:
-                moduleless_results.append((obj[0],f'{sig.module}.{sig.name}:{sig.kind}'))
+                moduleless_results.append(
+                    (obj[0], f'{sig.module}.{sig.name}:{sig.kind}'))
         if len(moduleless_results) == 1:
             return moduleless_results[0]
         elif len(moduleless_results) > 1:
@@ -288,7 +289,6 @@ class ThriftIndex(Index):
                 content[key] = []
             content[key].extend(group)
         return sorted(content.items(), key=lambda t: t[0]), False
-
 
 class ThriftDomain(Domain):
     name = 'thrift'
@@ -333,7 +333,7 @@ class ThriftDomain(Domain):
                      contnode):
         tgt = ThriftXRefRole.find_target(env, typ, target)
         if tgt is not None:
-            return make_refnode(builder, fromdocname, *tgt,
-                                contnode)
+            todoc, ref = tgt
+            return make_refnode(builder, fromdocname, todoc, ref, contnode)
         else:
             return None

--- a/sphinx_thrift/domain.py
+++ b/sphinx_thrift/domain.py
@@ -248,14 +248,14 @@ class ThriftServiceMethod(ThriftObject):
 class ThriftXRefRole(XRefRole):
     @staticmethod
     def find_target(env, target: str) -> Optional[str]:
-        for sig in env.domaindata['thrift']['objects'].keys():
+        for sig, obj in env.domaindata['thrift']['objects'].items():
             if str(sig.module) + '.' + sig.name == target:
-                return target + ':' + sig.kind
+                return (obj[0],f'{sig.module}.{sig.name}:{sig.kind}')
         return None
 
     def process_link(self, env, refnode, has_explicit_title: bool, title: str,
                      target: str) -> Tuple[str, str]:
-        return title, ThriftXRefRole.find_target(env, target)
+        return title, target
 
 
 class ThriftIndex(Index):
@@ -312,7 +312,8 @@ class ThriftDomain(Domain):
         'enum_field': ThriftXRefRole(),
         'struct': ThriftXRefRole(),
         'struct_field': ThriftXRefRole(),
-        'service': ThriftXRefRole()
+        'service': ThriftXRefRole(),
+        'service_method': ThriftXRefRole()
     }
     indices = [ThriftIndex]
     initial_data: Dict[str, Any] = {'objects': {}}
@@ -320,8 +321,9 @@ class ThriftDomain(Domain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node,
                      contnode):
         tgt = ThriftXRefRole.find_target(env, target)
+        print(target, tgt)
         if tgt is not None:
-            return make_refnode(builder, fromdocname, fromdocname, tgt,
+            return make_refnode(builder, fromdocname, *tgt,
                                 contnode)
         else:
             return None

--- a/sphinx_thrift/domain.py
+++ b/sphinx_thrift/domain.py
@@ -252,7 +252,7 @@ class ThriftXRefRole(XRefRole):
             target = f'None.{target}'
         moduleless_results = []
         for sig, obj in env.domaindata['thrift']['objects'].items():
-            if str(sig.module) + '.' + sig.name == target:
+            if f'{sig.module}.{sig.name}' == target:
                 return (obj[0], f'{sig.module}.{sig.name}:{sig.kind}')
             if sig.name == target:
                 moduleless_results.append(
@@ -261,7 +261,7 @@ class ThriftXRefRole(XRefRole):
             return moduleless_results[0]
         elif len(moduleless_results) > 1:
             logger = logging.getLogger(__name__)
-            logger.warning(f'Multiple targets found for {target}:')
+            logger.warning(f'{target} is ambiguous. Possible resolutions:')
             for tgt in moduleless_results:
                 logger.warning(f'   {tgt[0]}: {tgt[1]}')
         return None
@@ -289,6 +289,7 @@ class ThriftIndex(Index):
                 content[key] = []
             content[key].extend(group)
         return sorted(content.items(), key=lambda t: t[0]), False
+
 
 class ThriftDomain(Domain):
     name = 'thrift'
@@ -337,9 +338,9 @@ class ThriftDomain(Domain):
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node,
                      contnode):
-        tgt = ThriftXRefRole.find_target(env, typ, target)
-        if tgt is not None:
-            todoc, ref = tgt
-            return make_refnode(builder, fromdocname, todoc, ref, contnode)
+        targetdata = ThriftXRefRole.find_target(env, typ, target)
+        if targetdata is not None:
+            todoc, tgt = targetdata
+            return make_refnode(builder, fromdocname, todoc, tgt, contnode)
         else:
             return None

--- a/sphinx_thrift/domain.py
+++ b/sphinx_thrift/domain.py
@@ -301,6 +301,8 @@ class ThriftDomain(Domain):
         'enum_field': ObjType('enum_field', 'enum_field'),
         'struct': ObjType('struct', 'struct'),
         'struct_field': ObjType('struct_field', 'struct_field'),
+        'exception': ObjType('struct', 'struct'),
+        'exception_field': ObjType('struct_field', 'struct_field'),
         'service': ObjType('service', 'service'),
         'service_method': ObjType('service_method', 'service_method')
     }
@@ -312,6 +314,8 @@ class ThriftDomain(Domain):
         'enum_field': ThriftEnumField,
         'struct': ThriftStruct,
         'struct_field': ThriftStructField,
+        'exception': ThriftStruct,
+        'exception_field': ThriftStructField,
         'service': ThriftService,
         'service_method': ThriftServiceMethod
     }
@@ -323,6 +327,8 @@ class ThriftDomain(Domain):
         'enum_field': ThriftXRefRole(),
         'struct': ThriftXRefRole(),
         'struct_field': ThriftXRefRole(),
+        'exception': ThriftXRefRole(),
+        'exception_field': ThriftXRefRole(),
         'service': ThriftXRefRole(),
         'service_method': ThriftXRefRole()
     }

--- a/sphinx_thrift/domain.py
+++ b/sphinx_thrift/domain.py
@@ -247,10 +247,13 @@ class ThriftServiceMethod(ThriftObject):
 
 class ThriftXRefRole(XRefRole):
     @staticmethod
-    def find_target(env, target: str) -> Optional[str]:
+    def find_target(env, typ: str, target: str) -> Optional[str]:
+        if typ == 'module':
+            target = f'None.{target}'
         for sig, obj in env.domaindata['thrift']['objects'].items():
             if str(sig.module) + '.' + sig.name == target:
                 return (obj[0],f'{sig.module}.{sig.name}:{sig.kind}')
+        # TODO: try searching without specific module
         return None
 
     def process_link(self, env, refnode, has_explicit_title: bool, title: str,
@@ -305,7 +308,6 @@ class ThriftDomain(Domain):
     }
     roles = {
         'module': ThriftXRefRole(),
-        'namespace': ThriftXRefRole(),
         'constant': ThriftXRefRole(),
         'typedef': ThriftXRefRole(),
         'enum': ThriftXRefRole(),
@@ -320,8 +322,7 @@ class ThriftDomain(Domain):
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node,
                      contnode):
-        tgt = ThriftXRefRole.find_target(env, target)
-        print(target, tgt)
+        tgt = ThriftXRefRole.find_target(env, typ, target)
         if tgt is not None:
             return make_refnode(builder, fromdocname, *tgt,
                                 contnode)


### PR DESCRIPTION
- cross-document crossrefs
- ``:thrift:module:`ModuleName` `` reference instead of ``:thrift:module:`None.ModuleName` ``
- support for "automatic module resolution" eg. ``:thrift:[role]:`ReferencedItem` `` works if there is only one module with a `ReferencedItem`
- exception and exception_field roles as "aliases" for struct and struct_field